### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -50,6 +52,8 @@ jobs:
 
   build:
     needs: test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/xixu-me/tzst/security/code-scanning/2](https://github.com/xixu-me/tzst/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow and jobs that do not already have one. The `test` and `build` jobs will be assigned the minimal permissions required for their tasks. Based on the workflow's operations, `contents: read` is sufficient for these jobs, as they only need to read the repository contents to perform testing and building. The `publish` job already has a `permissions` block, so no changes are needed there.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
