### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -67,6 +67,8 @@ jobs:
 
   docs-quality-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/xixu-me/tzst/security/code-scanning/5](https://github.com/xixu-me/tzst/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the `docs-quality-check` job. Since this job only reads the repository contents to check documentation links and coverage, it should be granted the minimal permission of `contents: read`. This change ensures that the job does not have unnecessary write permissions, improving the security of the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
